### PR TITLE
Fix objectlist + Misc bug fixes

### DIFF
--- a/listen.go
+++ b/listen.go
@@ -32,6 +32,7 @@ License.
 package gobacnet
 
 import (
+	"fmt"
 	"net"
 
 	log "github.com/sirupsen/logrus"
@@ -122,7 +123,11 @@ func (c *Client) handleMsg(src *net.UDPAddr, b []byte) {
 				return
 			}
 		case bactype.Error:
-			log.Error("Error Class %d Code %d", apdu.Error.Class, apdu.Error.Code)
+			err := fmt.Errorf("Error Class %d Code %d", apdu.Error.Class, apdu.Error.Code)
+			err = c.tsm.Send(int(apdu.InvokeId), err)
+			if err != nil {
+				log.Warningf("unable to send error to %d: %v", apdu.InvokeId, err)
+			}
 		default:
 			// Ignore it
 			log.WithFields(log.Fields{"raw": b}).Debug("An ignored packet went through")

--- a/objectlist.go
+++ b/objectlist.go
@@ -22,7 +22,7 @@ func (c *Client) objectListLen(dev bactype.Device) (int, error) {
 
 	resp, err := c.ReadProperty(dev, rp)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("reading property failed: %v", err)
 	}
 
 	if len(resp.Object.Properties) == 0 {
@@ -53,10 +53,10 @@ func (c *Client) objectsRange(dev bactype.Device, start, end int) ([]bactype.Obj
 	}
 	resp, err := c.ReadMultiProperty(dev, rpm)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to read multiple property: %v", err)
 	}
 	if len(resp.Objects) == 0 {
-		return nil, fmt.Errorf("No data was returned")
+		return nil, fmt.Errorf("no data was returned")
 	}
 
 	objs := make([]bactype.Object, len(resp.Objects[0].Properties))
@@ -64,7 +64,7 @@ func (c *Client) objectsRange(dev bactype.Device, start, end int) ([]bactype.Obj
 	for i, prop := range resp.Objects[0].Properties {
 		id, ok := prop.Data.(bactype.ObjectID)
 		if !ok {
-			return nil, fmt.Errorf("Expected type Object ID, got %T", prop.Data)
+			return nil, fmt.Errorf("expected type Object ID, got %T", prop.Data)
 		}
 		objs[i].ID = id
 	}
@@ -89,7 +89,7 @@ func (c *Client) objectList(dev *bactype.Device) error {
 
 	l, err := c.objectListLen(*dev)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to get list length: %v", err)
 	}
 
 	// Scan size is broken
@@ -101,7 +101,7 @@ func (c *Client) objectList(dev *bactype.Device) error {
 
 		objs, err := c.objectsRange(*dev, start, end)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to retrieve objects between %d and %d: %v", start, end, err)
 		}
 		objectCopy(dev.Objects, objs)
 	}
@@ -110,7 +110,7 @@ func (c *Client) objectList(dev *bactype.Device) error {
 	if start <= end {
 		objs, err := c.objectsRange(*dev, start, end)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to retrieve objects between %d and %d: %v", start, end, err)
 		}
 		objectCopy(dev.Objects, objs)
 	}
@@ -159,11 +159,11 @@ func (c *Client) objectInformation(dev *bactype.Device) error {
 	for i, r := range resp.Objects {
 		name, ok = r.Properties[0].Data.(string)
 		if !ok {
-			return fmt.Errorf("Incorrect data returned")
+			return fmt.Errorf("expecting string got %T", r.Properties[0].Data)
 		}
 		description, ok = r.Properties[1].Data.(string)
 		if !ok {
-			return fmt.Errorf("Incorrect data returned")
+			return fmt.Errorf("expecting string got %T", r.Properties[1].Data)
 		}
 		obj := dev.Objects[keys[i].Type][keys[i].Instance]
 		obj.Name = name

--- a/objectlist.go
+++ b/objectlist.go
@@ -24,6 +24,11 @@ func (c *Client) objectListLen(dev bactype.Device) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+
+	if len(resp.Object.Properties) == 0 {
+		return 0, fmt.Errorf("no data was returned")
+	}
+
 	data, ok := resp.Object.Properties[0].Data.(uint32)
 	if !ok {
 		return 0, fmt.Errorf("Unable to get object length")

--- a/readmulti.go
+++ b/readmulti.go
@@ -89,11 +89,21 @@ func (c *Client) ReadMultiProperty(dev bactype.Device, rp bactype.ReadMultiplePr
 			continue
 		}
 
-		b, err = c.tsm.Receive(id, time.Duration(5)*time.Second)
+		raw, err := c.tsm.Receive(id, time.Duration(5)*time.Second)
 		if err != nil {
 			err = fmt.Errorf("unable to receive id %d: %v", id, err)
 			continue
 		}
+
+		switch v := raw.(type) {
+		case error:
+			return out, err
+		case []byte:
+			b = v
+		default:
+			return out, fmt.Errorf("received unknown datatype %T", raw)
+		}
+
 		dec := encoding.NewDecoder(b)
 
 		var apdu bactype.APDU

--- a/tsm/transactions.go
+++ b/tsm/transactions.go
@@ -51,13 +51,12 @@ type state struct {
 	id           int
 	state        int
 	requestTimer int
-	data         chan []byte
+	data         chan interface{}
 }
 
 // TSM is the transaction state manager. It handles passing data to other
 // processes and keeping track of what transactions are currently processed
 type TSM struct {
-	size   int
 	mutex  sync.Mutex
 	states map[int]*state
 	pool   sync.Pool
@@ -70,11 +69,10 @@ type TSM struct {
 // New creates a new transaction manager
 func New(size int) *TSM {
 	t := &TSM{
-		size:   size,
 		states: make(map[int]*state), pool: sync.Pool{
 			New: func() interface{} {
 				s := new(state)
-				s.data = make(chan []byte)
+				s.data = make(chan interface{})
 				return s
 			},
 		},
@@ -96,13 +94,13 @@ func New(size int) *TSM {
 }
 
 // Send data to invoked id
-func (t *TSM) Send(id int, b []byte) error {
+func (t *TSM) Send(id int, b interface{}) error {
 	t.mutex.Lock()
 	s, ok := t.states[id]
 	t.mutex.Unlock()
 
 	if !ok {
-		return fmt.Errorf("id is not receiving")
+		return fmt.Errorf("id %d is not receiving", id)
 	}
 	s.data <- b
 	return nil
@@ -110,13 +108,13 @@ func (t *TSM) Send(id int, b []byte) error {
 
 // Receive attempts to receive a byte array from the invoked id. If a time out
 // period has passed then an error is returned
-func (t *TSM) Receive(id int, timeout time.Duration) ([]byte, error) {
+func (t *TSM) Receive(id int, timeout time.Duration) (interface{}, error) {
 	t.mutex.Lock()
 	s, ok := t.states[id]
 	t.mutex.Unlock()
 
 	if !ok {
-		return nil, fmt.Errorf("id is not sending")
+		return nil, fmt.Errorf("id %d is not sending", id)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/tsm/transactions_test.go
+++ b/tsm/transactions_test.go
@@ -45,7 +45,6 @@ func TestTSM(t *testing.T) {
 	for i := 0; i < size-1; i++ {
 		_, err = tsm.ID(ctx)
 		if err != nil {
-			t.Logf("Getting ID %d:", tsm.currID)
 			t.Fatal(err)
 		}
 	}
@@ -83,23 +82,22 @@ func TestDataTransaction(t *testing.T) {
 	ids := make([]int, size)
 	var err error
 
-	for i := 0; i < size-1; i++ {
+	for i := 0; i < size; i++ {
 		ids[i], err = tsm.ID(context.Background())
 		if err != nil {
-			t.Logf("Getting ID %d:", tsm.currID)
 			t.Fatal(err)
 		}
 	}
 
 	go func() {
-		err = tsm.Send(ids[0], []byte("Hello First ID"))
+		err = tsm.Send(ids[0], "Hello First ID")
 		if err != nil {
 			t.Error(err)
 		}
 	}()
 
 	go func() {
-		err = tsm.Send(ids[1], []byte("Hello Second ID"))
+		err = tsm.Send(ids[1], "Hello Second ID")
 		if err != nil {
 			t.Error(err)
 		}
@@ -110,7 +108,12 @@ func TestDataTransaction(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		t.Log(string(b))
+		s, ok := b.(string)
+		if !ok {
+			t.Errorf("type was not preseved")
+			return
+		}
+		t.Log(s)
 	}()
 
 	b, err := tsm.Receive(ids[1], time.Duration(5)*time.Second)
@@ -118,5 +121,10 @@ func TestDataTransaction(t *testing.T) {
 		t.Error(err)
 	}
 
-	t.Log(string(b))
+	s, ok := b.(string)
+	if !ok {
+		t.Errorf("type was not preseved")
+		return
+	}
+	t.Log(s)
 }


### PR DESCRIPTION
Add some context to errors going upstream
Fix error that occurs when no object list is passed back by device.
Change tsm to pass interfaces{} instead of byte arrays.