### PR TITLE
support for parsing ASCII-encoded strings

### DIFF
--- a/encoding/apdu.go
+++ b/encoding/apdu.go
@@ -61,7 +61,7 @@ func (e *Encoder) APDU(a bactype.APDU) error {
 	case bactype.Abort:
 		return fmt.Errorf("Decoded Aborted")
 	default:
-		return fmt.Errorf("Unknown PDU type:%d", meta.DataType)
+		return fmt.Errorf("Unknown PDU type:%d", meta.DataType())
 	}
 	return nil
 }

--- a/encoding/appdata.go
+++ b/encoding/appdata.go
@@ -100,18 +100,34 @@ func (e *Encoder) string(s string) {
 	e.write(stringUTF8)
 	e.write([]byte(s))
 }
+
 func (d *Decoder) string(s *string, len int) error {
 	var t stringType
 	d.decode(&t)
-	if t != stringUTF8 {
-		return fmt.Errorf("unsupported string format %d", t)
-	}
-
 	b := make([]byte, len)
 	d.decode(b)
-	*s = string(b)
+	if t == stringASCII {
+		*s = asciiDecode(b)
+	} else if t == stringUTF8 {
+		*s = string(b)
+	} else {
+		return fmt.Errorf("unsupported string format %d", t)
+	}
 	return d.Error()
 }
+
+func asciiDecode(data []byte) string {
+	result := ""
+	for _, b := range data {
+		if b == 0 {
+			continue
+		}
+		d := string(b)
+		result += d
+	}
+	return result
+}
+
 func (e *Encoder) octetstring(b []byte) {
 	e.write([]byte(b))
 }

--- a/encoding/const.go
+++ b/encoding/const.go
@@ -61,5 +61,6 @@ type stringType uint8
 
 // Supported String types
 const (
-	stringUTF8 stringType = 0
+	stringUTF8  stringType = 0
+	stringASCII stringType = 4
 )


### PR DESCRIPTION
Enhance the functionality of the "func (d *Decoder) string()" method in the "encoding" package to include support for parsing ASCII-encoded strings.